### PR TITLE
Feature/ApplicativeError

### DIFF
--- a/src/core/applicative.rs
+++ b/src/core/applicative.rs
@@ -29,9 +29,55 @@ impl<A> Applicative for Id<A> {
     }
 }
 
+pub trait ApplicativeError: Applicative {
+    type ErrorT;
+
+    fn handle_error_with<F>(self, f: F) -> Self::Outter<Self::Inner>
+    where
+        F: FnMut(Self::ErrorT) -> Self::Outter<Self::Inner>;
+
+    fn raise_error(error: Self::ErrorT) -> Self::Outter<Self::Inner>;
+}
+
+impl<A, E> ApplicativeError for Result<A, E> {
+    type ErrorT = E;
+
+    fn handle_error_with<F>(self, mut f: F) -> Self::Outter<Self::Inner>
+    where
+        F: FnMut(Self::ErrorT) -> Self::Outter<Self::Inner>
+    {
+        match self {
+            Err(e) => f(e),
+            _ => self
+        }
+    }
+
+    fn raise_error(error: Self::ErrorT) -> Self::Outter<Self::Inner> {
+        Err(error)
+    }
+}
+
+impl<A> ApplicativeError for Option<A> {
+    type ErrorT = ();
+
+    fn handle_error_with<F>(self, mut f: F) -> Self::Outter<Self::Inner>
+        where
+            F: FnMut(Self::ErrorT) -> Self::Outter<Self::Inner>
+    {
+        match self {
+            None => f(()),
+            _ => self
+        }
+    }
+
+    fn raise_error(_error: Self::ErrorT) -> Self::Outter<Self::Inner> {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::Applicative;
+    use super::{Applicative, ApplicativeError};
 
     #[test]
     fn option() {
@@ -57,5 +103,31 @@ mod tests {
 
         let value = 3;
         assert_eq!(Id::pure(value), Id(3));
+    }
+
+    #[test]
+    fn handle_error_with_for_result() {
+        let value = Err(());
+        let handler = |_err| { Ok(3) };
+        assert_eq!(value.handle_error_with(handler), Ok(3));
+    }
+
+    #[test]
+    fn raise_error_for_result() {
+        let err = Result::<u64, String>::raise_error("ERROR!".to_string());
+        assert_eq!(err, Err("ERROR!".to_string()));
+    }
+
+    #[test]
+    fn handle_error_with_for_option() {
+        let value = None;
+        let handler = |_| { Some(3) };
+        assert_eq!(value.handle_error_with(handler), Some(3));
+    }
+
+    #[test]
+    fn raise_error_for_option() {
+        let err = Option::<u64>::raise_error(());
+        assert_eq!(err, None);
     }
 }

--- a/src/core/applicative.rs
+++ b/src/core/applicative.rs
@@ -44,11 +44,11 @@ impl<A, E> ApplicativeError for Result<A, E> {
 
     fn handle_error_with<F>(self, mut f: F) -> Self::Outter<Self::Inner>
     where
-        F: FnMut(Self::ErrorT) -> Self::Outter<Self::Inner>
+        F: FnMut(Self::ErrorT) -> Self::Outter<Self::Inner>,
     {
         match self {
             Err(e) => f(e),
-            _ => self
+            _ => self,
         }
     }
 
@@ -61,12 +61,12 @@ impl<A> ApplicativeError for Option<A> {
     type ErrorT = ();
 
     fn handle_error_with<F>(self, mut f: F) -> Self::Outter<Self::Inner>
-        where
-            F: FnMut(Self::ErrorT) -> Self::Outter<Self::Inner>
+    where
+        F: FnMut(Self::ErrorT) -> Self::Outter<Self::Inner>,
     {
         match self {
             None => f(()),
-            _ => self
+            _ => self,
         }
     }
 
@@ -108,7 +108,7 @@ mod tests {
     #[test]
     fn handle_error_with_for_result() {
         let value = Err(());
-        let handler = |_err| { Ok(3) };
+        let handler = |_err| Ok(3);
         assert_eq!(value.handle_error_with(handler), Ok(3));
     }
 
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn handle_error_with_for_option() {
         let value = None;
-        let handler = |_| { Some(3) };
+        let handler = |_| Some(3);
         assert_eq!(value.handle_error_with(handler), Some(3));
     }
 


### PR DESCRIPTION
I don't like this raise_error at all. I followed the cats documentation, but I don't think it translates well to Rust. Instead of writing
`Err(e)`
one has to write
`Result::raise_error(e)`
why would anyone do this?